### PR TITLE
Allow user to measure Literal tokens by their char size

### DIFF
--- a/binary_choice.py
+++ b/binary_choice.py
@@ -6,7 +6,7 @@ import grammar
 from grammar import _Choice, RHSItem
 from typing import List
 
-class Binary_Choices(grammar.Transform_Base):
+class Binary_Choices(grammar.TransformBase):
     """After transformation, each _Choice node will
     have two alternatives.
     """

--- a/choicebot.py
+++ b/choicebot.py
@@ -6,7 +6,7 @@ import argparse
 
 from pygramm.llparse import *
 from pygramm.generator import Gen_State
-from pygramm.grammar import Grammar, Factor_Empty
+from pygramm.grammar import Grammar, FactorEmpty
 
 
 def cli() -> object:
@@ -67,7 +67,7 @@ def generate_sentence(g: Grammar, budget: int,
 def main():
     args = cli()
     gram = parse(args.grammar)
-    transform = Factor_Empty(gram)
+    transform = FactorEmpty(gram)
     transform.transform_all_rhs(gram)
     budget = args.budget
     generate_sentence(gram, budget, args.escapes)

--- a/config.py
+++ b/config.py
@@ -1,0 +1,6 @@
+"""
+Configuration file for Pygramm.
+"""
+
+HUGE = 999_999_999   # Larger than any sentence we will generate
+LEN_BASED_SIZE = False  # use the len(text) in _Literal as the their size (True) or consider each _Literal=1 (False)?

--- a/demo_gen.py
+++ b/demo_gen.py
@@ -1,20 +1,20 @@
 """Glue together parsing and random sentence generation"""
 
-from pygramm.grammar import Factor_Empty
+from pygramm.grammar import FactorEmpty
 from pygramm.llparse import *
 from pygramm.generator import *
 from pygramm.binary_choice import Binary_Choices
 
 # f = open("data/english.txt")
 # gram = parse(f)
-# xform = Factor_Empty(gram)
+# xform = FactorEmpty(gram)
 # xform.transform_all_rhs(gram)
 
 f = open("data/simple_seq.txt")
 gram = parse(f)
 log.debug(f"Grammar is {gram}")
 
-# xform = grammar.Factor_Empty(gram)
+# xform = grammar.FactorEmpty(gram)
 # xform.transform_all_rhs(gram)
 
 binarize = Binary_Choices(gram)

--- a/generator.py
+++ b/generator.py
@@ -151,7 +151,7 @@ class Gen_State:
         sym = self.suffix.pop()
         assert isinstance(sym, _Literal)
         self.text += sym.text
-        self.budget_used += 1
+        self.budget_used += sym.min_tokens()
 
     # Non-terminal symbols, including kleene star and choices,
     # provide an opportunity for external control of options.

--- a/llparse.py
+++ b/llparse.py
@@ -7,6 +7,7 @@ revised in discussion with Ziyad Alsaeed.
 import logging
 from typing import TextIO, List
 
+import pygramm.config as config
 from pygramm.grammar import Grammar, RHSItem, _Literal
 from pygramm.lex import TokenStream, TokenCat
 
@@ -21,10 +22,11 @@ class InputError(Exception):
     pass
 
 
-def parse(srcfile: TextIO) -> Grammar:
+def parse(srcfile: TextIO, len_based_size=False) -> Grammar:
     """Interface function to LL parser of BNF.
     Populates TERMINALS and NONTERMINALS
     """
+    config.LEN_BASED_SIZE = len_based_size  # update global accordingly to be used in grammar.
     stream = TokenStream(srcfile)
     gram = Grammar(srcfile.name.rpartition('/')[-1])
     _grammar(stream, gram)

--- a/llparse.py
+++ b/llparse.py
@@ -13,7 +13,7 @@ from pygramm.lex import TokenStream, TokenCat
 
 logging.basicConfig()
 log = logging.getLogger(__name__)
-log.setLevel(logging.INFO)
+# log.setLevel(logging.INFO)
 
 
 class InputError(Exception):
@@ -181,7 +181,7 @@ def _bnf_symbol(stream: TokenStream, gram: Grammar) -> RHSItem:
     token = stream.take()
     if token.kind == TokenCat.STRING or token.kind == TokenCat.CHAR:
         # log.debug("Forming literal")
-        return gram.literal(token.value[1:-1]) # Clips quotes
+        return gram.literal(token.value[1:-1])  # Clips quotes
     elif token.kind == TokenCat.IDENT:
         # log.debug("Forming symbol")
         return gram.symbol(token.value)


### PR DESCRIPTION
Allowed the user to choose to either consider Literals cost by their char size or as a token (default method). If Literals are considered as tokens, then each literal would cost 1 no matter how many characters it has. However, if they are considered as strings then their cost would equal the length of the string. 

In addition to the main change described above, this pull request includes other minor changes. 

- Create a config file to hold all global variables. 
- Applied many minor changes to be compatible with PEP8 as much as possible. 